### PR TITLE
Adding check of refs to handle promotions of tags

### DIFF
--- a/posix/clone
+++ b/posix/clone
@@ -43,7 +43,12 @@ export GIT_COMMITTER_EMAIL=${GIT_AUTHOR_EMAIL}
 # TODO we should ultimately look at the ref, since
 # we need something compatible with deployment events.
 
-case $DRONE_BUILD_EVENT in
+CLONE_TYPE=$DRONE_BUILD_EVENT
+case $DRONE_COMMIT_REF in
+  refs/tags/* ) CLONE_TYPE=tag ;;
+esac
+
+case $CLONE_TYPE in
 pull_request)
 	clone-pull-request
 	;;


### PR DESCRIPTION
Checking the DRONE_COMMIT_REF to see if it's a tag

Used case instead of if [[ ]] since [[ ]] is a bash only and case makes it more portable to sh

@bradrydzewski let me know if anything else jumps out at you :)