### PR TITLE
Add git-lfs to Linux images

### DIFF
--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -1,5 +1,5 @@
-FROM alpine:3.6
-RUN apk add --no-cache ca-certificates git openssh curl perl
+FROM alpine:3.7
+RUN apk add --no-cache ca-certificates git git-lfs openssh curl perl
 
 ADD posix/* /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/clone"]

--- a/docker/Dockerfile.linux.arm
+++ b/docker/Dockerfile.linux.arm
@@ -1,5 +1,5 @@
-FROM arm32v6/alpine:3.6
-RUN apk add --no-cache ca-certificates git openssh curl perl
+FROM arm32v6/alpine:3.7
+RUN apk add --no-cache ca-certificates git git-lfs openssh curl perl
 
 ADD posix/* /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/clone"]

--- a/docker/Dockerfile.linux.arm6
+++ b/docker/Dockerfile.linux.arm6
@@ -1,5 +1,5 @@
-FROM arm32v6/alpine:3.6
-RUN apk add --no-cache ca-certificates git openssh curl perl
+FROM arm32v6/alpine:3.7
+RUN apk add --no-cache ca-certificates git git-lfs openssh curl perl
 
 ADD posix/* /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/clone"]

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -1,5 +1,5 @@
-FROM arm64v8/alpine:3.6
-RUN apk add --no-cache ca-certificates git openssh curl perl
+FROM arm64v8/alpine:3.7
+RUN apk add --no-cache ca-certificates git git-lfs openssh curl perl
 
 ADD posix/* /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/clone"]

--- a/docker/Dockerfile.linux.arm7
+++ b/docker/Dockerfile.linux.arm7
@@ -1,5 +1,5 @@
-FROM arm32v6/alpine:3.6
-RUN apk add --no-cache ca-certificates git openssh curl perl
+FROM arm32v6/alpine:3.7
+RUN apk add --no-cache ca-certificates git git-lfs openssh curl perl
 
 ADD posix/* /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/clone"]

--- a/docker/Dockerfile.linux.arm8
+++ b/docker/Dockerfile.linux.arm8
@@ -1,5 +1,5 @@
-FROM arm64v8/alpine:3.6
-RUN apk add --no-cache ca-certificates git openssh curl perl
+FROM arm64v8/alpine:3.7
+RUN apk add --no-cache ca-certificates git git-lfs openssh curl perl
 
 ADD posix/* /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/clone"]


### PR DESCRIPTION
Per discussion in https://github.com/drone-plugins/drone-git/pull/73, this change pre-installs git-lfs in the Linux plugins.  That will allow the default clone action to be able to clone LFS objects from public repositories.

Private repositories will require provider-specific authentication, which this change does not cover.  But having git-lfs pre-installed will make it easier for provider-specific clone plugins to be built `FROM` this plugin.