### PR TITLE
Fetch commit by SHA

### DIFF
--- a/posix/clone-commit
+++ b/posix/clone-commit
@@ -13,5 +13,5 @@ fi
 set -e
 set -x
 
-git fetch ${FLAGS} origin +refs/heads/${DRONE_COMMIT_BRANCH}:
+git fetch -v ${FLAGS} origin ${DRONE_COMMIT_SHA}:
 git checkout ${DRONE_COMMIT_SHA} -b ${DRONE_COMMIT_BRANCH}


### PR DESCRIPTION
Rather than attempting to deduce the ref on which a given sha resides, `git` supports fetching by SHA and delegating ref selection to the server (as of version [2.5](https://github.com/git/git/blob/master/Documentation/RelNotes/2.5.0.txt)).

This functionality _should_ be relatively safe (available in [github](https://github.com/git/git/commit/68ee628932c2196742b77d2961c5e16360734a62) and [bitbucket](https://jira.atlassian.com/browse/BSERV-8268)).

In case this plugin is also used elsewhere where server-side support is disabled, I'd be happy to add a plugin parameter to enable/disable fetch by SHA. _Thanks!_

(This _should_ get around an issue we've run into recently, wherein github deployment webhook triggers for a given hash result in failed `git checkout` due to the wrong ref having been fetched - potentially related to [issue 81](https://github.com/drone-plugins/drone-git/issues/81) on the previous incarnation of this repo).

References:
 * [ServerFault: pull specific commit](https://serverfault.com/questions/117255/git-pull-specific-revision-from-remote-repository)
 * [StackOverflow: fetching specific commit](https://stackoverflow.com/questions/14872486/retrieve-specific-commit-from-a-remote-git-repository/30701724)