### PR TITLE
Allow git clone without root

### DIFF
--- a/posix/clone
+++ b/posix/clone
@@ -4,7 +4,7 @@ if [[ ! -z "${DRONE_WORKSPACE}" ]]; then
 	cd ${DRONE_WORKSPACE}
 fi
 
-if [ -z "$HOME" ]; then
+if [ -z "${HOME}" ]; then
 	HOME=/root
 fi
 
@@ -12,7 +12,7 @@ fi
 # the netrc file.
 
 if [[ ! -z "${DRONE_NETRC_MACHINE}" ]]; then
-	cat <<EOF > /$HOME/.netrc
+	cat <<EOF > /${HOME}/.netrc
 machine ${DRONE_NETRC_MACHINE}
 login ${DRONE_NETRC_USERNAME}
 password ${DRONE_NETRC_PASSWORD}
@@ -24,12 +24,12 @@ fi
 # known hosts file.
 
 if [[ ! -z "${SSH_KEY}" ]]; then
-	mkdir /$HOME/.ssh
-	echo -n "$SSH_KEY" > /$HOME/.ssh/id_rsa
-	chmod 600 /$HOME/.ssh/id_rsa
+	mkdir /${HOME}/.ssh
+	echo -n "$SSH_KEY" > /${HOME}/.ssh/id_rsa
+	chmod 600 /${HOME}/.ssh/id_rsa
 
-	touch /$HOME/.ssh/known_hosts
-	chmod 600 /$HOME/.ssh/known_hosts
+	touch /${HOME}/.ssh/known_hosts
+	chmod 600 /${HOME}/.ssh/known_hosts
 	ssh-keyscan -H ${DRONE_NETRC_MACHINE} > /etc/ssh/ssh_known_hosts 2> /dev/null
 fi
 

--- a/posix/clone
+++ b/posix/clone
@@ -7,6 +7,7 @@ fi
 if [ -z "${HOME}" ]; then
 	HOME=/root
 fi
+export HOME
 
 # if the netrc enviornment variables exist, write
 # the netrc file.

--- a/posix/clone
+++ b/posix/clone
@@ -4,11 +4,15 @@ if [[ ! -z "${DRONE_WORKSPACE}" ]]; then
 	cd ${DRONE_WORKSPACE}
 fi
 
+if [ -z "$HOME" ]; then
+	HOME=/root
+fi
+
 # if the netrc enviornment variables exist, write
 # the netrc file.
 
 if [[ ! -z "${DRONE_NETRC_MACHINE}" ]]; then
-	cat <<EOF > /root/.netrc
+	cat <<EOF > /$HOME/.netrc
 machine ${DRONE_NETRC_MACHINE}
 login ${DRONE_NETRC_USERNAME}
 password ${DRONE_NETRC_PASSWORD}
@@ -20,12 +24,12 @@ fi
 # known hosts file.
 
 if [[ ! -z "${SSH_KEY}" ]]; then
-	mkdir /root/.ssh
-	echo -n "$SSH_KEY" > /root/.ssh/id_rsa
-	chmod 600 /root/.ssh/id_rsa
+	mkdir /$HOME/.ssh
+	echo -n "$SSH_KEY" > /$HOME/.ssh/id_rsa
+	chmod 600 /$HOME/.ssh/id_rsa
 
-	touch /root/.ssh/known_hosts
-	chmod 600 /root/.ssh/known_hosts
+	touch /$HOME/.ssh/known_hosts
+	chmod 600 /$HOME/.ssh/known_hosts
 	ssh-keyscan -H ${DRONE_NETRC_MACHINE} > /etc/ssh/ssh_known_hosts 2> /dev/null
 fi
 

--- a/posix/posix_gen.go
+++ b/posix/posix_gen.go
@@ -9,7 +9,7 @@ if [[ ! -z "${DRONE_WORKSPACE}" ]]; then
 	cd ${DRONE_WORKSPACE}
 fi
 
-if [ -z "$HOME" ]; then
+if [ -z "${HOME}" ]; then
 	HOME=/root
 fi
 
@@ -17,7 +17,7 @@ fi
 # the netrc file.
 
 if [[ ! -z "${DRONE_NETRC_MACHINE}" ]]; then
-	cat <<EOF > /$HOME/.netrc
+	cat <<EOF > /${HOME}/.netrc
 machine ${DRONE_NETRC_MACHINE}
 login ${DRONE_NETRC_USERNAME}
 password ${DRONE_NETRC_PASSWORD}
@@ -29,12 +29,12 @@ fi
 # known hosts file.
 
 if [[ ! -z "${SSH_KEY}" ]]; then
-	mkdir /$HOME/.ssh
-	echo -n "$SSH_KEY" > /$HOME/.ssh/id_rsa
-	chmod 600 /$HOME/.ssh/id_rsa
+	mkdir /${HOME}/.ssh
+	echo -n "$SSH_KEY" > /${HOME}/.ssh/id_rsa
+	chmod 600 /${HOME}/.ssh/id_rsa
 
-	touch /$HOME/.ssh/known_hosts
-	chmod 600 /$HOME/.ssh/known_hosts
+	touch /${HOME}/.ssh/known_hosts
+	chmod 600 /${HOME}/.ssh/known_hosts
 	ssh-keyscan -H ${DRONE_NETRC_MACHINE} > /etc/ssh/ssh_known_hosts 2> /dev/null
 fi
 

--- a/posix/posix_gen.go
+++ b/posix/posix_gen.go
@@ -9,11 +9,15 @@ if [[ ! -z "${DRONE_WORKSPACE}" ]]; then
 	cd ${DRONE_WORKSPACE}
 fi
 
+if [ -z "$HOME" ]; then
+	HOME=/root
+fi
+
 # if the netrc enviornment variables exist, write
 # the netrc file.
 
 if [[ ! -z "${DRONE_NETRC_MACHINE}" ]]; then
-	cat <<EOF > /root/.netrc
+	cat <<EOF > /$HOME/.netrc
 machine ${DRONE_NETRC_MACHINE}
 login ${DRONE_NETRC_USERNAME}
 password ${DRONE_NETRC_PASSWORD}
@@ -25,12 +29,12 @@ fi
 # known hosts file.
 
 if [[ ! -z "${SSH_KEY}" ]]; then
-	mkdir /root/.ssh
-	echo -n "$SSH_KEY" > /root/.ssh/id_rsa
-	chmod 600 /root/.ssh/id_rsa
+	mkdir /$HOME/.ssh
+	echo -n "$SSH_KEY" > /$HOME/.ssh/id_rsa
+	chmod 600 /$HOME/.ssh/id_rsa
 
-	touch /root/.ssh/known_hosts
-	chmod 600 /root/.ssh/known_hosts
+	touch /$HOME/.ssh/known_hosts
+	chmod 600 /$HOME/.ssh/known_hosts
 	ssh-keyscan -H ${DRONE_NETRC_MACHINE} > /etc/ssh/ssh_known_hosts 2> /dev/null
 fi
 

--- a/posix/posix_gen.go
+++ b/posix/posix_gen.go
@@ -10,8 +10,9 @@ if [[ ! -z "${DRONE_WORKSPACE}" ]]; then
 fi
 
 if [ -z "${HOME}" ]; then
-	HOME=/root
+	export HOME=/root
 fi
+export HOME
 
 # if the netrc enviornment variables exist, write
 # the netrc file.


### PR DESCRIPTION
In some environment, drone is not running as root (can be the case in Redhat Openshift for example).
This PR allows git-clone to run as non-root in case ${HOME} is set with a global variable defined at the pipeline level :

```
---
kind: pipeline
type: kubernetes
name: openshift

environment:
  HOME: /drone/src
```