### PR TITLE
Adding Windows 2004

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -134,6 +134,38 @@ trigger:
 ---
 kind: pipeline
 type: ssh
+name: windows-2004-amd64
+
+platform:
+  os: windows
+
+server:
+  host:
+    from_secret: windows_server_2004
+  password:
+    from_secret: windows_password
+  user:
+    from_secret: windows_username
+
+steps:
+  - name: build
+    commands:
+      - docker login -u $env:USERNAME -p $env:PASSWORD
+      - docker build -f docker/Dockerfile.windows.2004 -t drone/git:windows-2004-amd64 .
+      - docker push drone/git:windows-2004-amd64
+    environment:
+      USERNAME:
+        from_secret: docker_username
+      PASSWORD:
+        from_secret: docker_password
+
+trigger:
+  event:
+    - push
+
+---
+kind: pipeline
+type: ssh
 name: windows-1903-amd64
 
 platform:
@@ -221,6 +253,7 @@ depends_on:
 - linux-amd64
 - linux-arm64
 - linux-arm
+- windows-2004-amd64
 - windows-1909-amd64
 - windows-1903-amd64
 - windows-1809-amd64

--- a/docker/Dockerfile.windows.2004
+++ b/docker/Dockerfile.windows.2004
@@ -1,0 +1,20 @@
+# escape=`
+
+FROM mcr.microsoft.com/windows/servercore:2004 AS git
+SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
+    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.21.0.windows.1/MinGit-2.21.0-64-bit.zip -OutFile git.zip; `
+    Expand-Archive git.zip -DestinationPath C:\git;
+
+FROM mcr.microsoft.com/powershell:nanoserver-2004
+COPY --from=git /git /git
+
+ADD windows/* /bin/
+
+# https://github.com/PowerShell/PowerShell/issues/6211#issuecomment-367477137
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\PowerShell"
+
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+CMD [ "pwsh", "C:\\bin\\clone.ps1" ]

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -53,3 +53,9 @@ manifests:
       architecture: amd64
       os: windows
       version: 1909
+  -
+    image: drone/git:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-2004-amd64
+    platform:
+      architecture: amd64
+      os: windows
+      version: 2004


### PR DESCRIPTION
Added to support https://github.com/drone-plugins/drone-docker/pull/284

For this to work fully it will need Windows 2004 hosts to build the images.