### PR TITLE
Allow setting file permissions on exit for non-root use

### DIFF
--- a/posix/clone
+++ b/posix/clone
@@ -69,3 +69,9 @@ tag)
 	clone-commit
 	;;
 esac
+
+if [[ -n "${CI}" ]]; then
+	if [[ -n "${CI_UIDGID}" ]]; then
+		chown -Rf ${CI_UIDGID} ./ 
+	fi
+fi


### PR DESCRIPTION
I am working with this plugin in an environment where we are not permitted to use the root user in any internally authored containers. As such, I want to be able to set the UID and GID of the files from the checkout so that I can pick them up in the next container of our drone pipeline.