### PR TITLE
Disable auto line ending conversion in Windows Dockerfiles

### DIFF
--- a/docker/Dockerfile.windows.1803
+++ b/docker/Dockerfile.windows.1803
@@ -6,6 +6,7 @@ SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $Progress
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.21.0.windows.1/MinGit-2.21.0-64-bit.zip -OutFile git.zip; `
     Expand-Archive git.zip -DestinationPath C:\git;
+RUN C:\git\cmd\git.exe config --system core.autocrlf false
 
 FROM mcr.microsoft.com/powershell:nanoserver-1803 
 COPY --from=git /git /git

--- a/docker/Dockerfile.windows.1809
+++ b/docker/Dockerfile.windows.1809
@@ -6,6 +6,7 @@ SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $Progress
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.21.0.windows.1/MinGit-2.21.0-64-bit.zip -OutFile git.zip; `
     Expand-Archive git.zip -DestinationPath C:\git;
+RUN C:\git\cmd\git.exe config --system core.autocrlf false
 
 FROM mcr.microsoft.com/powershell:nanoserver-1809
 COPY --from=git /git /git

--- a/docker/Dockerfile.windows.1903
+++ b/docker/Dockerfile.windows.1903
@@ -6,6 +6,7 @@ SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $Progress
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.21.0.windows.1/MinGit-2.21.0-64-bit.zip -OutFile git.zip; `
     Expand-Archive git.zip -DestinationPath C:\git;
+RUN C:\git\cmd\git.exe config --system core.autocrlf false
 
 FROM mcr.microsoft.com/powershell:nanoserver-1903
 COPY --from=git /git /git

--- a/docker/Dockerfile.windows.1909
+++ b/docker/Dockerfile.windows.1909
@@ -6,6 +6,7 @@ SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $Progress
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.21.0.windows.1/MinGit-2.21.0-64-bit.zip -OutFile git.zip; `
     Expand-Archive git.zip -DestinationPath C:\git;
+RUN C:\git\cmd\git.exe config --system core.autocrlf false
 
 FROM mcr.microsoft.com/powershell:nanoserver-1909
 COPY --from=git /git /git


### PR DESCRIPTION
We (Grafana Labs) have  been having test failures on Windows due to automatic conversion of line endings to CRLF on Windows. I tracked it down to being caused by the Git config parameter core.autocrlf being set to true in the Windows Docker image of the Drone Git plugin. This PR proposes to disable the parameter, so line endings aren't altered by Git on checkout.

I tested the image and it solves our issue.