### PR TITLE
Update git version to 2.30.2 to fix git clone vulnerability

### DIFF
--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.13
 RUN apk add --no-cache ca-certificates git git-lfs openssh curl perl aws-cli
 
 ADD posix/* /usr/local/bin/

--- a/docker/Dockerfile.linux.arm
+++ b/docker/Dockerfile.linux.arm
@@ -1,4 +1,4 @@
-FROM arm32v6/alpine:3.12
+FROM arm32v6/alpine:3.13
 RUN apk add --no-cache ca-certificates git git-lfs openssh curl perl
 
 ADD posix/* /usr/local/bin/

--- a/docker/Dockerfile.linux.arm6
+++ b/docker/Dockerfile.linux.arm6
@@ -1,4 +1,4 @@
-FROM arm32v6/alpine:3.12
+FROM arm32v6/alpine:3.13
 RUN apk add --no-cache ca-certificates git git-lfs openssh curl perl
 
 ADD posix/* /usr/local/bin/

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -1,4 +1,4 @@
-FROM arm64v8/alpine:3.12
+FROM arm64v8/alpine:3.13
 RUN apk add --no-cache ca-certificates git git-lfs openssh curl perl
 
 ADD posix/* /usr/local/bin/

--- a/docker/Dockerfile.linux.arm7
+++ b/docker/Dockerfile.linux.arm7
@@ -1,4 +1,4 @@
-FROM arm32v6/alpine:3.12
+FROM arm32v6/alpine:3.13
 RUN apk add --no-cache ca-certificates git git-lfs openssh curl perl
 
 ADD posix/* /usr/local/bin/

--- a/docker/Dockerfile.linux.arm8
+++ b/docker/Dockerfile.linux.arm8
@@ -1,4 +1,4 @@
-FROM arm64v8/alpine:3.12
+FROM arm64v8/alpine:3.13
 RUN apk add --no-cache ca-certificates git git-lfs openssh curl perl
 
 ADD posix/* /usr/local/bin/


### PR DESCRIPTION
Updates the version of alpine base image to 3.13 which installs git version 2.30.2. Updated git version has the fix for the security vulnerability listed here: https://github.blog/2021-03-09-git-clone-vulnerability-announced/