### PR TITLE
Add server 2022 images

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -12,6 +12,7 @@ def main(ctx):
     linux('amd64'),
     windows('1903'),
     windows('1809'),
+    windows('2022'),
   ]
 
   after = manifest()

--- a/.drone.yml
+++ b/.drone.yml
@@ -102,6 +102,38 @@ steps:
 ---
 kind: pipeline
 type: ssh
+name: windows-2022-amd64
+
+platform:
+  os: windows
+
+server:
+  host:
+    from_secret: windows_server_2022
+  password:
+    from_secret: windows_password
+  user:
+    from_secret: windows_username
+
+steps:
+- name: build
+  commands:
+  - docker login -u $env:USERNAME -p $env:PASSWORD
+  - docker build -f docker/Dockerfile.windows.2022 -t drone/git:windows-2022-amd64 .
+  - docker push drone/git:windows-2022-amd64
+  environment:
+    USERNAME:
+      from_secret: docker_username
+    PASSWORD:
+      from_secret: docker_password
+
+trigger:
+  event:
+  - push
+
+---
+kind: pipeline
+type: ssh
 name: windows-1909-amd64
 
 platform:
@@ -221,6 +253,7 @@ depends_on:
 - linux-amd64
 - linux-arm64
 - linux-arm
+- windows-2022-amd64
 - windows-1909-amd64
 - windows-1903-amd64
 - windows-1809-amd64

--- a/docker/Dockerfile.windows.2022
+++ b/docker/Dockerfile.windows.2022
@@ -1,14 +1,12 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/servercore:ltsc2022 AS git
-SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-
-RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
-    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.33.0.windows.2/MinGit-2.33.0.2-64-bit.zip -OutFile git.zip; `
-    Expand-Archive git.zip -DestinationPath C:\git;
-
 FROM mcr.microsoft.com/powershell:nanoserver-ltsc2022
-COPY --from=git /git /git
+
+RUN `
+  mkdir tmp && mkdir bin`
+	&& curl -sSfLo tmp/file.zip https://github.com/git-for-windows/git/releases/download/v2.33.0.windows.2/MinGit-2.33.0.2-64-bit.zip `
+  && tar -C c:\git -oxzf tmp/file.zip`
+  && rmdir /Q /S tmp
 
 ADD windows/* /bin/
 

--- a/docker/Dockerfile.windows.2022
+++ b/docker/Dockerfile.windows.2022
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/powershell:nanoserver-ltsc2022
 
 RUN `
-  mkdir tmp && mkdir bin`
+  mkdir tmp && mkdir git`
 	&& curl -sSfLo tmp/file.zip https://github.com/git-for-windows/git/releases/download/v2.33.0.windows.2/MinGit-2.33.0.2-64-bit.zip `
   && tar -C c:\git -oxzf tmp/file.zip`
   && rmdir /Q /S tmp

--- a/docker/Dockerfile.windows.2022
+++ b/docker/Dockerfile.windows.2022
@@ -1,0 +1,20 @@
+# escape=`
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2022 AS git
+SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
+    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.33.0.windows.2/MinGit-2.33.0.2-64-bit.zip -OutFile git.zip; `
+    Expand-Archive git.zip -DestinationPath C:\git;
+
+FROM mcr.microsoft.com/powershell:nanoserver-ltsc2022
+COPY --from=git /git /git
+
+ADD windows/* /bin/
+
+# https://github.com/PowerShell/PowerShell/issues/6211#issuecomment-367477137
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\PowerShell"
+
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+CMD [ "pwsh", "C:\\bin\\clone.ps1" ]

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -53,3 +53,9 @@ manifests:
       architecture: amd64
       os: windows
       version: 1909
+  -
+    image: drone/git:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-2022-amd64
+    platform:
+      architecture: amd64
+      os: windows
+      version: 2022


### PR DESCRIPTION
This adds the new windows server 2022 docker images.

It probably needs a new sserver 2022 base build slave. There are no differences for ssh and docker installation 