### PR TITLE
git timeout

### DIFF
--- a/posix/clone
+++ b/posix/clone
@@ -88,17 +88,24 @@ case $DRONE_COMMIT_REF in
 esac
 
 git_clone_retry(){
-	retries="${PLUGIN_RETRIES:-0}"
+	retries="${PLUGIN_RETRIES:-5}"
+        timeout="${PLUGIN_TIMEOUT:-300}"
 	if [ -n "${retries##*[0-9]*}" ] || [ "${retries}" -lt 0 ]; then
 		echo "PLUGIN_RETRIES defined but is not a number: ${retries}" >&2
 		exit 1
 	fi
+	if [ -n "${timeout##*[0-9]*}" ] || [ "${timeout}" -lt 0 ]; then
+		echo "PLUGIN_TIMEOUT defined but is not a number: ${timeout}" >&2
+		exit 1
+	fi
 
-	echo "Cloning with ${retries} retries"
+	echo "Cloning with ${retries} retries, ${timeout}s timeout"
 	n=0
-	until [ "$n" -gt "${retries}" ]; do
-		$1 && return
-		n=$((n+1))
+        until [ "$n" -gt "${retries}" ]; do
+                echo "$DRONE_STAGE_MACHINE attempt $((n+1))"
+                timeout $timeout $1 && return
+                sleep 15
+                n=$((n+1))
 	done
 	
 	exit 1


### PR DESCRIPTION
Hi,
I have observed the initial `git fetch` to hang in certain situations, specifically IBM Cloud. That happens even with the `retries` option in place. It's freezing indefinitely.

Logically, if `git fetch` were unresponsive for a certain amount of time wouldn't it make sense to retry?  

Yet that functionality has been missing.  

I am now able to confirm, this modification does fix the issue.  

Other details:  

- Adding a 'sleep' between retries, since if there is a very quick failure, you'd want to wait.  
- Setting conservative default values (5 retries, 300 second timeout).   Both retries and timeouts are very useful.  Is there a counter-argument to not enabling them by default?

This would need to be done: https://github.com/drone-runners/drone-runner-docker/pull/44/files

Open to any suggestions.  

60 second timeout seems better, the reason for 300s is to be very sure it doesn't affect any large repositories.   Could be put back to 60 if you like.  

